### PR TITLE
feat: add pocketbase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@esri/calcite-components": "^3.2.1",
         "@tailwindcss/vite": "^4.1.12",
+        "pocketbase": "^0.26.2",
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
@@ -2016,6 +2017,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pocketbase": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/pocketbase/-/pocketbase-0.26.2.tgz",
+      "integrity": "sha512-WA8EOBc3QnSJh8rJ3iYoi9DmmPOMFIgVfAmIGux7wwruUEIzXgvrO4u0W2htfQjGIcyezJkdZOy5Xmh7SxAftw==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@esri/calcite-components": "^3.2.1",
     "@tailwindcss/vite": "^4.1.12",
+    "pocketbase": "^0.26.2",
     "tailwindcss": "^4.1.12"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -3,10 +3,13 @@
   setAssetPath("./assets/");
 
   import data from "./assets/content/data.json";
+  import { results } from "./lib/pocketbase";
   import "@esri/calcite-components/components/calcite-card";
   import "@esri/calcite-components/components/calcite-chip";
   import "@esri/calcite-components/components/calcite-action";
   import "@esri/calcite-components/components/calcite-tooltip";
+
+  console.log('results', results);
 
   // variables
   let myTimeout;

--- a/src/lib/pocketbase/index.js
+++ b/src/lib/pocketbase/index.js
@@ -1,0 +1,24 @@
+// pb docs: https://github.com/pocketbase/js-sdk
+import PocketBase from 'pocketbase';
+
+// connect to pb instance
+const url = 'https://aecdemo.pockethost.io/'
+const client = new PocketBase(url)
+
+// store data
+const tags = await client.collection('tags').getFullList();
+const links = await client.collection('links').getFullList();
+const media = await client.collection('media').getFullList();
+const industries = await client.collection('industries').getFullList();
+const engagements = await client.collection('engagements').getFullList({
+  expand: 'industry,media,links,tags'
+});
+
+// export results
+export const results = {
+  tags,
+  links,
+  media,
+  industries,
+  engagements
+}


### PR DESCRIPTION
Hey @michaelgaigg,

- Added the PocketBase lib so we can pull from the demo database. 
- Unfortunately, PocketHost is a subscription based thing now (so we'd need to host PB somewhere if we end up using it).
- I'm pulling in the data on App.svelte (and console logging it).

Here are the endpoints if needed:

- [industries](https://aecdemo.pockethost.io/api/collections/industries/records)
- [links](https://aecdemo.pockethost.io/api/collections/links/records)
- [media](https://aecdemo.pockethost.io/api/collections/media/records)
- [engagements](https://aecdemo.pockethost.io/api/collections/engagements/records)
- [tags](https://aecdemo.pockethost.io/api/collections/tags/records)